### PR TITLE
Some fixes, added Sock->GetLastError

### DIFF
--- a/Source/gm_bromsock/LuaWrappers/BromSock.cpp
+++ b/Source/gm_bromsock/LuaWrappers/BromSock.cpp
@@ -577,6 +577,15 @@ namespace GMBSOCK {
 		return 0;
 	}
 
+	GMOD_FUNCTION(SOCK_GetLastError) {
+		DEBUGPRINTFUNC;
+
+		LUA->CheckType(1, UD_TYPE_SOCKET);
+		LUA->PushString((GETSOCK(1))->Sock->lastError);
+
+		return 1;
+	}
+
 	GMOD_FUNCTION(SOCK__TOSTRING) {
 		DEBUGPRINTFUNC;
 

--- a/Source/gm_bromsock/LuaWrappers/BromSock.cpp
+++ b/Source/gm_bromsock/LuaWrappers/BromSock.cpp
@@ -92,6 +92,8 @@ namespace GMBSOCK {
 		bool ret = s->Sock->bind(ip, port) && s->Sock->listen();
 		if (ret) s->CreateWorkers();
 
+		LUA->PushBool(ret);
+
 		return 1;
 	}
 

--- a/Source/gm_bromsock/LuaWrappers/BromSock.h
+++ b/Source/gm_bromsock/LuaWrappers/BromSock.h
@@ -40,6 +40,7 @@ namespace GMBSOCK {
 	GMOD_FUNCTION(SOCK_GetIP);
 	GMOD_FUNCTION(SOCK_GetPort);
 	GMOD_FUNCTION(SOCK_GetState);
+	GMOD_FUNCTION(SOCK_GetLastError);
 }
 
 #endif

--- a/Source/gm_bromsock/Objects/BSEzSock.h
+++ b/Source/gm_bromsock/Objects/BSEzSock.h
@@ -42,6 +42,7 @@ namespace GMBSOCK {
 		SockState state;
 
 		int lastCode;
+		char lastError[256];
 
 		EzSock();
 		~EzSock();

--- a/Source/gm_bromsock/Objects/Engine.cpp
+++ b/Source/gm_bromsock/Objects/Engine.cpp
@@ -54,6 +54,7 @@ namespace GMBSOCK {
 			ADDFUNC("GetIP", SOCK_GetIP);
 			ADDFUNC("GetPort", SOCK_GetPort);
 			ADDFUNC("GetState", SOCK_GetState);
+			ADDFUNC("GetLastError", SOCK_GetLastError);
 			ADDFUNC("AddWorker", SOCK_AddWorker);
 			ADDFUNC("SetTimeout", SOCK_SetTimeout);
 			ADDFUNC("SetOption", SOCK_SetOption);

--- a/Source/gm_bromsock/Objects/SockWrapper.cpp
+++ b/Source/gm_bromsock/Objects/SockWrapper.cpp
@@ -316,7 +316,6 @@ namespace GMBSOCK {
 		this->CallDisconnect();
 
 		this->KillWorkers();
-		this->Sock->close();
 
 		delete this->Sock;
 		this->Sock = new EzSock();


### PR DESCRIPTION
* Fixed Sock->Listen not returning whether it succeeded or not, like bind does.
* Added Sock->GetLastError, to be used if Sock->Listen or Sock->Bind fails
* Removed a duplicate sock close call

I'm not very good at c programming so I'm not sure if the way I did GetLastError is the best way (especially the memcpy for posix).

I've tested this on both windows and ubuntu and it works fine, however GetLastError returns quite useless messages on ubuntu sadly.